### PR TITLE
Fix URL when grouping by `hostname`

### DIFF
--- a/maas.py
+++ b/maas.py
@@ -111,7 +111,7 @@ class Fetcher:
         return groups
 
     def _fetch_all_machines(self) -> dict:
-        url = "{}/machines".format(self.maas_api_url.rstrip())
+        url = "{}/machines/".format(self.maas_api_url.rstrip())
 
         return self._api_call(url)
 


### PR DESCRIPTION
Currently grouping by hostname with this code will fail because the URL is not valid and does not end with a trailing `/` 

Tested on maas 3.1.0